### PR TITLE
Remove "Quelle: xxx" source note

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -73,6 +73,7 @@ class OFDBAgent(Agent.Movies):
             if len(plot_text) > 0:
               summary = plot_text[0].replace('<br />', '\n')
               summary = re.sub('(\r)?\n((\r)?\n)+', '\n', summary) # Replace 2 or more newlines with just 1
+              summary = re.sub('(<b>Quelle.*?<br><br>)', '', summary) # Remove the sometimes occuring "Quelle: ..." source note
               summary = String.StripTags(summary).strip() # Strip HTML tags
 
               if summary != '':


### PR DESCRIPTION
Remove the sometimes occuring 'Quelle: ...' source note at the beginning of the summary.

Example page **with** source note: http://www.ofdb.de/plot/272730,658896,True-Story---Spiel-um-Macht

Summary on Website:
> Quelle: filmstarts.de
>
>Der Journalist Michael Finkel (Jonah Hill) hat sich bis an die Spitze geschrieben....

This resulted in following summary in Plex:
> Quelle: filmstarts.deDer Journalist Michael Finkel (Jonah Hill) hat sich bis an die Spitze geschrieben....